### PR TITLE
feat: gb28181 save the latitude and longitude in DeviceInfo and Devic…

### DIFF
--- a/plugin/gb28181/device.go
+++ b/plugin/gb28181/device.go
@@ -312,6 +312,8 @@ func (d *Device) onMessage(req *sip.Request, tx sip.ServerTransaction, msg *gb28
 			d.UpdateTime = time.Now()
 			if err := d.plugin.DB.Model(d).Updates(map[string]interface{}{
 				"update_time": d.UpdateTime,
+				"longitude":   msg.Longitude,
+				"latitude":    msg.Latitude,
 			}).Error; err != nil {
 				d.Error("save device status failed", "error", err)
 			}
@@ -323,6 +325,8 @@ func (d *Device) onMessage(req *sip.Request, tx sip.ServerTransaction, msg *gb28
 		d.Model = msg.Model
 		d.Firmware = msg.Firmware
 		d.UpdateTime = time.Now()
+		d.Latitude = msg.Latitude
+		d.Longitude = msg.Longitude
 		// 更新设备信息到数据库
 		if d.plugin.DB != nil {
 			if err := d.plugin.DB.Model(d).Updates(map[string]interface{}{
@@ -331,6 +335,8 @@ func (d *Device) onMessage(req *sip.Request, tx sip.ServerTransaction, msg *gb28
 				"model":        d.Model,
 				"firmware":     d.Firmware,
 				"update_time":  d.UpdateTime,
+				"longitude":    d.Longitude,
+				"latitude":     d.Latitude,
 			}).Error; err != nil {
 				d.Error("save device info failed", "error", err)
 			}

--- a/plugin/gb28181/pkg/message.go
+++ b/plugin/gb28181/pkg/message.go
@@ -145,6 +145,8 @@ type (
 		CmdType           string
 		SN                int // 请求序列号，一般用于对应 request 和 response
 		DeviceID          string
+		Longitude         string // 经度
+		Latitude          string // 纬度
 		DeviceName        string
 		Manufacturer      string
 		Model             string


### PR DESCRIPTION
This pull request introduces the functionality to save the latitude and longitude information within the DeviceInfo and DeviceStatus objects for the GB28181 protocol. The goal is to enhance the tracking and monitoring capabilities of devices by capturing their geographical location.