### PR TITLE
fix(config): prevent panic by checking reflect.Value.IsValid()

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -239,9 +239,14 @@ func (config *Config) ParseUserFile(conf map[string]any) {
 				}
 			} else {
 				fv := prop.assign(k, v)
-				prop.File = fv.Interface()
-				if prop.Env == nil {
-					prop.Ptr.Set(fv)
+				if fv.IsValid() {
+					prop.File = fv.Interface()
+					if prop.Env == nil {
+						prop.Ptr.Set(fv)
+					}
+				} else {
+					// continue invalid field
+					slog.Error("Attempted to access invalid field during config parsing: %s", v)
 				}
 			}
 		}


### PR DESCRIPTION
/pkg/config/config.go:242 出错，在解析配置文件时，尝试对一个反射值调用 .Interface()。确保在调用 reflect.Value.Interface()之前，该 reflect.Value是有效的（IsValid() == true）​​