### PR TITLE
fix(hls): correct LLHLS timestamps and SPS context handling

### DIFF
--- a/plugin/hls/llhls.go
+++ b/plugin/hls/llhls.go
@@ -126,12 +126,18 @@ func (ll *LLMuxer) Run() (err error) {
 				ts := v.Timestamp
 				var au [][]byte
 				if subscriber.VideoReader.Value.IDR {
-					au = append(au, ctx.SPS(), ctx.PPS())
+					// 动态获取最新编码上下文，避免闭包捕获旧 SPS 导致 extractor 崩溃
+					if c := subscriber.Publisher.GetVideoCodecCtx(); c != nil {
+						if hc, ok := c.GetBase().(*codec.H264Ctx); ok {
+							au = append(au, hc.SPS(), hc.PPS())
+						}
+					}
 				}
 				for buffer := range v.Raw.(*pkg.Nalus).RangePoint {
 					au = append(au, buffer.Buffers...)
 				}
-				return ll.Muxer.WriteH264(time.Now().Add(ts-ll.Muxer.SegmentMinDuration), v.GetPTS(), au)
+				// GetPTS() 返回 90kHz tick 数，gohlslib 期望真实时间 Duration，改用 ts+v.CTS
+				return ll.Muxer.WriteH264(time.Now().Add(ts-ll.Muxer.SegmentMinDuration), ts+v.CTS, au)
 			}
 		case *codec.H265Ctx:
 			ll.Muxer.VideoTrack.Codec = &codecs.H265{
@@ -142,12 +148,17 @@ func (ll *LLMuxer) Run() (err error) {
 			videoFunc = func(v *pkg.AVFrame) (err error) {
 				var au [][]byte
 				if subscriber.VideoReader.Value.IDR {
-					au = append(au, ctx.VPS(), ctx.SPS(), ctx.PPS())
+					// 动态获取最新编码上下文
+					if c := subscriber.Publisher.GetVideoCodecCtx(); c != nil {
+						if hc, ok := c.GetBase().(*codec.H265Ctx); ok {
+							au = append(au, hc.VPS(), hc.SPS(), hc.PPS())
+						}
+					}
 				}
 				for buffer := range v.Raw.(*pkg.Nalus).RangePoint {
 					au = append(au, buffer.Buffers...)
 				}
-				return ll.Muxer.WriteH265(time.Now().Add(v.Timestamp-ll.Muxer.SegmentMinDuration), v.GetPTS(), au)
+				return ll.Muxer.WriteH265(time.Now().Add(v.Timestamp-ll.Muxer.SegmentMinDuration), v.Timestamp+v.CTS, au)
 			}
 		}
 	}


### PR DESCRIPTION
## 问题描述

LL-HLS 输出不可用（针对 GB28181 摄像头实测）：

1. **切片时长 0.54ms / bitrate 5.6Gbps**：`llhls.go` 用 `v.GetPTS()` 作为 `gohlslib.WriteH264/WriteH265` 的时间参数。但 `GetPTS()` 返回的是 90kHz tick 数（`(Timestamp+CTS)*90/time.Millisecond`），而 gohlslib 期望真实 `time.Duration`（纳秒）。帧间隔 40ms 被解释为 3.6µs，一个 GOP（150 帧）只有 540µs → 切片 0.54ms、BANDWIDTH 5.6Gbps。

2. **Muxer 每 2 秒崩溃重试**：`videoFunc` 闭包捕获了 `Run()` 开始时的旧 codec context。摄像头 SPS 变化后，DTS extractor 报 `invalid SPS: invalid pic_order_cnt_type: 6`，Muxer 崩溃 → subscribe → 读取几帧 → 又崩溃，无限循环，`stream.m3u8` 时常为空。

## 修复

1. **时间单位修正**：`v.GetPTS()` → `ts + v.CTS`（`Timestamp` 本身是纳秒 `time.Duration`，`v.CTS` 同理）。H264/H265 两条路径都改。

2. **动态获取最新编码上下文**：IDR 帧时不再使用闭包捕获的 `ctx`，而是 `subscriber.Publisher.GetVideoCodecCtx()` 现场取最新 SPS/PPS/VPS，避免旧 context 的 SPS 与当前流不匹配导致 extractor 崩溃。

## 验证（真实 GB28181 摄像头 + watch 页面双流）

| 指标 | 修复前 | 修复后 |
|------|--------|--------|
| 切片时长 | 0.54ms | **2s / 4s** ✅ |
| BANDWIDTH | 5.6Gbps | **518Kbps / 259Kbps** ✅ |
| 分辨率 | -10x-9 (002) | **1280x720 双流** ✅ |
| SPS 崩溃循环 | 每 2s 一次 | **0 次** ✅ |

- 001/002 两路摄像头 LLHLS 均正常（`index.m3u8` / `stream.m3u8` 参数正常）
- 修复后的二进制用 `-tags sqlite` 编译（纯 Go sqlite driver，无 CGO），本地 smoke test 插件加载正常后部署

## 备注

改动最小化：仅 `plugin/hls/llhls.go`，+15/-4。
